### PR TITLE
Fix duplicate npm workspace name: sdrx backend → sdrx-backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ npm run dev --workspace=wxstation
 npm run start --workspace=sdrx        # Angular uses `start`, not `dev`
 
 # Dev servers — backends
-npm run dev:sdrx                      # SDRx Express backend (port 8080)
+npm run dev:sdrx                      # SDRx Express backend (port 8080, workspace: sdrx-backend)
 cd backends/roboarm && uvicorn main:app --reload --port 8000
 cd backends/wxstation && uvicorn main:app --reload --port 8001
 ```

--- a/backends/sdrx/package.json
+++ b/backends/sdrx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sdrx",
+  "name": "sdrx-backend",
   "version": "0.1.0",
   "private": true,
   "description": "Express backend API for SDRx control and telemetry",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "install:all": "npm install",
     "build:all": "npm run build --workspaces --if-present",
     "test:all": "npm run test --workspaces --if-present",
-    "dev:sdrx": "npm run dev --workspace=sdrx",
-    "build:sdrx": "npm run build --workspace=sdrx",
+    "dev:sdrx": "npm run dev --workspace=sdrx-backend",
+    "build:sdrx": "npm run build --workspace=sdrx-backend",
     "dev:wxstation": "npm run dev --workspace=wxstation-backend",
     "dev:roboarm": "npm run dev --workspace=roboarm-backend"
   },


### PR DESCRIPTION
Closes #78

## Summary
`apps/sdrx` and `backends/sdrx` both had `"name": "sdrx"` causing `EDUPLICATEWORKSPACE` in CI after the rename in #77. Renamed the backend package to `sdrx-backend` and updated the root scripts.

## Changes
- `backends/sdrx/package.json`: `"name"` changed from `sdrx` to `sdrx-backend`
- `package.json`: `dev:sdrx` and `build:sdrx` scripts updated to `--workspace=sdrx-backend`
- `AGENTS.md`: command comment updated