### PR TITLE
Fix duplicate workspace name: sdrx backend → sdrx-backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ npm run dev --workspace=wxstation
 npm run start --workspace=sdrx        # Angular uses `start`, not `dev`
 
 # Dev servers — backends
-npm run dev:sdrx                      # SDRx Express backend (port 8080)
+npm run dev:sdrx                      # SDRx Express backend (port 8080, workspace: sdrx-backend)
 cd backends/roboarm && uvicorn main:app --reload --port 8000
 cd backends/wxstation && uvicorn main:app --reload --port 8001
 ```

--- a/backends/sdrx/package.json
+++ b/backends/sdrx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sdrx",
+  "name": "sdrx-backend",
   "version": "0.1.0",
   "private": true,
   "description": "Express backend API for SDRx control and telemetry",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "install:all": "npm install",
     "build:all": "npm run build --workspaces --if-present",
     "test:all": "npm run test --workspaces --if-present",
-    "dev:sdrx": "npm run dev --workspace=sdrx",
-    "build:sdrx": "npm run build --workspace=sdrx",
+    "dev:sdrx": "npm run dev --workspace=sdrx-backend",
+    "build:sdrx": "npm run build --workspace=sdrx-backend",
     "dev:wxstation": "npm run dev --workspace=wxstation-backend",
     "dev:roboarm": "npm run dev --workspace=roboarm-backend"
   },


### PR DESCRIPTION
npm workspaces requires unique names across apps/* and backends/*. apps/sdrx and backends/sdrx both had name 'sdrx', causing EDUPLICATEWORKSPACE.

## Summary
<!-- What changed and why -->

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Infrastructure / CI
- [ ] Docs / config

## Testing
<!-- How was this verified? (local dev server, build pass, manual test, etc.) -->

## Checklist
- [ ] `npm run build:all` passes locally
- [ ] No secrets or credentials committed
- [ ] Targets `dev` branch (not `main` directly)
