### PR TITLE
dev->main

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ appropriate Kubernetes microservice. The entire setup demonstrates Engineering
 skills across a broad spectrum, including network, system, Cloud (DevOps),
 and software engineering using a variety of tech stacks, languages, and AWS services.
 
-*Note*: These backends are available at api.travler7282.com/`<backendname>`/api/v1/`<endpoint>`
-All backends support the heathz and readyz endpoints, many endpoints support the docs endpoint
+*Note*: These backends are available at `api.travler7282.com/<backendname>/api/v1/<endpoint>`
+All backends support the `heathz` and `readyz` endpoints, many endpoints support the `docs` endpoint
 and will display the SwagerUI OpenAPI documentation.
 - `backends/sdrx`: Node 24 + Express + TypeScript — SDRx control and telemetry API
 - `backends/roboarm`: Python 3.11 + FastAPI — RoboArm BLE controller with camera feed
 - `backends/wxstation`: Python 3.11 + FastAPI — WXStation weather data aggregator
-- `backends/springtime`: Spring Boot - Demonstration of using Spring Boot to create a RESTful API
+- `backends/springtime`: Java 17 + Spring Boot - Demonstration of using Spring Boot to create a RESTful API
 
 ## Additional Cloud Information
 

--- a/apps/devops-assistant/README.md
+++ b/apps/devops-assistant/README.md
@@ -1,0 +1,15 @@
+# DevOps Assistant Frontend (WIP)
+
+Frontend for the DevOps Assistant backend (FastAPI, RAG, log ingestion, and LLM Q&A).
+
+## What It Does
+- Provides a user interface for interacting with the DevOps Assistant backend
+- Allows users to upload logs, ask questions, and view answers
+
+## Scripts
+- `npm run dev` - start local dev server
+- `npm run build` - build production assets
+- `npm run preview` - preview production build locally
+
+## Deployment
+This app is deployed under the `/devops-assistant/` route by the repository deployment workflows.

--- a/apps/landing-page/README.md
+++ b/apps/landing-page/README.md
@@ -1,23 +1,20 @@
-# landing-page
+# Landing Page
 
-Landing page application built with Vite + TypeScript (no UI framework).
+Vite + TypeScript (no framework) landing page for www.travler7282.com.
 
 ## What It Does
-
 - Serves as the root experience for the site
-- Provides navigation cards to the apps:
+- Provides navigation to:
   - `/roboarm/` (RoboArm)
   - `/wxstation/` (WXStation)
   - `/sdrx/` (SDRx)
 
 ## Scripts
-
 - `npm run dev` - start local dev server
-- `npm run build` - type-check and build production assets
+- `npm run build` - build production assets
 - `npm run preview` - preview production build locally
 
 ## Implementation Notes
-
 - `index.html` contains the page markup
 - `src/main.ts` is the Vite entry module
-- `src/style.css` contains styling imported by `src/main.ts`
+- `src/style.css` contains styling

--- a/apps/roboarm/README.md
+++ b/apps/roboarm/README.md
@@ -1,12 +1,16 @@
-# RoboArm
+# RoboArm Frontend
 
-React + TypeScript application built with Vite.
+React 19 + Vite frontend for the RoboArm robotic arm controller.
+
+## What It Does
+- Provides a UI for controlling the RoboArm via BLE and camera
+- Connects to the RoboArm backend for BLE and camera streaming
 
 ## Scripts
-
 - `npm run dev` - start local dev server
-- `npm run build` - type-check and build production assets
+- `npm run build` - build production assets
 - `npm run preview` - preview production build locally
 - `npm run lint` - run ESLint
 
+## Deployment
 This app is deployed under the `/roboarm/` route by the repository deployment workflows.

--- a/apps/sdrx/README.md
+++ b/apps/sdrx/README.md
@@ -1,29 +1,19 @@
-# SDRx
+# SDRx Frontend
 
-Angular application for the monorepo.
+Angular 19 + Angular Material frontend for SDRx software-defined radio.
+
+## What It Does
+- Provides a UI for SDR state, tuning, and visualization
+- Connects to the SDRx backend for radio control
 
 ## Scripts
-
 - `npm run start` - start local dev server
 - `npm run build` - build production assets
 - `npm run watch` - build in watch mode
 - `npm run test` - run unit tests
 
+## Deployment
 This app is deployed under the `/sdrx/` route by the repository deployment workflows.
 
 ## Backend Domain Configuration
-
-The SDR backend URL is runtime-configured (no hardcoded domain in Angular code).
-
-Set the API domain in [apps/sdrx/public/runtime-config.js](apps/sdrx/public/runtime-config.js):
-
-```js
-window.__SDR_CONFIG__ = {
-	apiBaseUrl: 'https://your-backend-domain.example.com'
-};
-```
-
-Notes:
-
-- Use an empty `apiBaseUrl` to call same-origin routes.
-- This file is loaded before Angular bootstraps, so you can change backend domains without rebuilding the app bundle.
+Set the API domain in `public/runtime-config.js` before deployment if needed.

--- a/apps/wxstation/README.md
+++ b/apps/wxstation/README.md
@@ -1,11 +1,15 @@
-# WXStation
+# WXStation Frontend
 
-Vue 3 + TypeScript application built with Vite.
+Vue 3 + Vite frontend for the WXStation weather monitor.
+
+## What It Does
+- Provides a UI for viewing local and NWS weather data
+- Connects to the WXStation backend for live sensor and forecast data
 
 ## Scripts
-
 - `npm run dev` - start local dev server
-- `npm run build` - type-check and build production assets
+- `npm run build` - build production assets
 - `npm run preview` - preview production build locally
 
+## Deployment
 This app is deployed under the `/wxstation/` route by the repository deployment workflows.

--- a/backends/devops-assistant/README.md
+++ b/backends/devops-assistant/README.md
@@ -1,4 +1,4 @@
-# AI-DEVOPS-ASSISTANT
+# AI-DEVOPS-ASSISTANT (WIP)
 This directory is the ai-devops-assistant backend. This backend provides FastAPI
 services with a simple API with documentation available at the /docs endpoint.
 
@@ -65,3 +65,31 @@ kubectl create secret generic ai-devops-secrets-prod \
 ```
 
 If secrets already exist and must be rotated, delete and recreate them.
+
+## Endpoints
+
+All endpoints are available under `/devops-assistant/api/v1`.
+
+### GET /devops-assistant/api/v1/healthz
+- Health check
+- Response: `{ "status": "ok" }`
+
+### GET /devops-assistant/api/v1/readyz
+- Readiness check
+- Response: `{ "status": "ready" }`
+
+### POST /devops-assistant/api/v1/logs
+- Ingests raw log text (body)
+- Requires API key (header)
+- Response: `{ "added": <count> }`
+
+### GET /devops-assistant/api/v1/ask?question=... 
+- Answers a question about logs
+- Query param: `question` (string)
+- Requires API key (header)
+- Response: `{ "answer": "..." }`
+
+### DELETE /devops-assistant/api/v1/logs
+- Clears all logs from the database
+- Requires API key (header)
+- Response: `{ "status": "Logs cleared" }`

--- a/backends/roboarm/README.md
+++ b/backends/roboarm/README.md
@@ -1,0 +1,46 @@
+# RoboArm Backend
+
+Python 3.11+ FastAPI backend for BLE robotic arm control and camera streaming.
+
+## What It Does
+- Exposes BLE device scanning, connection, and command relay endpoints
+- Streams camera frames as JPEG or SVG fallback
+- Provides health and readiness endpoints
+- WebSocket for terminal BLE communication
+
+## Endpoints
+
+All endpoints are available at both the root and under `/roboarm/api/v1`.
+
+### GET /healthz
+- Health check
+- Response: `{ "status": "ok" }`
+
+### GET /readyz
+- Readiness check
+- Response: `{ "status": "ready" }`
+
+### GET /camera/frame, /camera/feed
+- Returns a JPEG image from the camera, or SVG if unavailable
+- Response: `image/jpeg` or `image/svg+xml`
+
+### GET /scan
+- Scans for nearby BLE devices named "Hiwonder"
+- Response: `[ { "name": "Hiwonder", "address": "..." }, ... ]`
+
+### WebSocket /ws/terminal
+- BLE terminal communication (connect, send, receive)
+- JSON message protocol
+
+## Running Locally
+
+```bash
+uvicorn main:app --reload --port 8000
+```
+
+## Docker
+
+```bash
+docker build -t roboarm-backend .
+docker run -p 8000:8000 roboarm-backend
+```

--- a/backends/sdrx/README.md
+++ b/backends/sdrx/README.md
@@ -44,3 +44,24 @@ Update image in `k8s/deployment.yaml`, then:
 kubectl apply -f backends/sdr-express-app/k8s/deployment.yaml
 kubectl rollout status deployment/sdr-express-app
 ```
+
+## Endpoints
+
+All endpoints are available at both the root and under `/srdx/api/v1`.
+
+### GET /healthz
+- Health check
+- Response: `{ "status": "ok" }`
+
+### GET /readyz
+- Readiness check
+- Response: `{ "ready": true, "service": "sdr-express-app" }`
+
+### GET /api/sdr/status
+- Returns current SDR state
+- Response: JSON object with frequency, bandwidth, gain, etc.
+
+### POST /api/sdr/tune
+- Tunes SDR to new parameters
+- Request body: `{ "frequencyHz": number, "bandwidthHz": number, "gainDb": number, "sampleRateHz": number, "mode": "AM"|"FM"|... }`
+- Response: updated SDR state or error

--- a/backends/springtime/README.md
+++ b/backends/springtime/README.md
@@ -1,0 +1,51 @@
+# Springtime Backend
+
+Java 17 + Spring Boot backend for the www-travler7282.com monorepo.
+
+## What It Does
+
+- Provides a REST API for greeting, health, and readiness checks
+- Used as a backend service for demonstration and health monitoring
+
+## Endpoints
+
+All endpoints are available at both the root and under `/springtime/api/v1`.
+
+### GET /greeting
+- Returns a greeting message
+- Query param: `name` (optional, default: "World")
+- Example: `GET /greeting?name=Michael`
+- Response: `{ "id": 1, "content": "Hello, Michael!" }`
+
+### GET /health, /healthz
+- Health check endpoints
+- Response: `{ "status": "UP" }`
+
+### GET /readyz
+- Readiness check endpoint
+- Response: `{ "status": "UP" }`
+
+## Running Locally
+
+Build and run with Gradle:
+```bash
+gradlew bootRun
+```
+
+Or build a JAR and run:
+```bash
+gradlew build
+java -jar build/libs/springtime-*.jar
+```
+
+## Docker
+
+Build the image:
+```bash
+docker build -t springtime-backend .
+```
+
+Run the container:
+```bash
+docker run -p 8080:8080 springtime-backend
+```

--- a/backends/wxstation/README.md
+++ b/backends/wxstation/README.md
@@ -1,0 +1,45 @@
+# WXStation Backend
+
+Python 3.11+ FastAPI backend for weather monitoring and aggregation.
+
+## What It Does
+- Provides local sensor and mock NWS weather data
+- Health and readiness endpoints for monitoring
+- Used as a backend for the WXStation frontend app
+
+## Endpoints
+
+All endpoints are available under `/wxstation/api/v1`.
+
+### GET /wxstation/api/v1/healthz
+- Health check
+- Response: `{ "status": "ok" }`
+
+### GET /wxstation/api/v1/readyz
+- Readiness check
+- Response: `{ "status": "ready" }`
+
+### GET /wxstation/api/v1/conditions/local
+- Returns current local sensor readings (mocked)
+- Response: JSON object with temperature, humidity, etc.
+
+### GET /wxstation/api/v1/conditions/nws
+- Returns latest mock NWS forecast
+- Response: JSON object with forecast details
+
+### GET /wxstation/api/v1/conditions
+- Returns combined local and NWS data
+- Response: JSON object with both local and NWS fields
+
+## Running Locally
+
+```bash
+uvicorn main:app --reload --port 8001
+```
+
+## Docker
+
+```bash
+docker build -t wxstation-backend .
+docker run -p 8001:8001 wxstation-backend
+```


### PR DESCRIPTION
## Summary
<!-- What changed and why -->

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Infrastructure / CI
- [ ] Docs

## Testing
<!-- How was this verified? -->

## Checklist
- [ ] Tested locally against dev environment
- [ ] No secrets committed
- [ ] `npm run build:all` passes
- [ ] Version bumped in package.json/pyproject.toml (if applicable)

## Summary by Sourcery

Document backend APIs and frontend apps across the monorepo to clarify capabilities and deployment paths.

Documentation:
- Expand the devops-assistant backend README with documented API endpoints for health, readiness, log ingestion, log querying, and log cleanup.
- Clarify the SDRx frontend README with app purpose, tech stack, and simplified backend runtime configuration notes.
- Describe SDRx backend endpoints for health/readiness checks and SDR status/tuning operations in its README.
- Refine the landing-page README with clearer site purpose, navigation targets, and simplified script descriptions.
- Enhance the RoboArm frontend README with its role, capabilities, and deployment details.
- Add new READMEs for the RoboArm, WXStation, and Springtime backends detailing their purpose, key endpoints, and local/Docker run instructions.
- Update the WXStation frontend README with app purpose, behavior, and deployment route information.
- Add a README for the DevOps Assistant frontend describing its purpose, basic usage, and deployment route.
- Improve the root repository README with corrected backend endpoint notation and additional Spring Boot stack details.